### PR TITLE
Recipes 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
     fi;
     export CHIMERADIR="$HOME/chimera/Chimera.app/Contents/Resources";
   fi
+- rm -rf $CHIMERADIR/lib/python2.7/site-packages/{AutoDockTools,MolKit,PyBabel,mglutil,mmLib,mslib} || true;
 # Get miniconda. Take the right version, so re-installing python is hopefully not needed.
 - if test -e $HOME/miniconda/bin; then
     echo "miniconda already installed.";
@@ -61,9 +62,12 @@ install:
 - conda config --add channels omnia
 - conda config --add channels rdkit
 - conda config --add channels insilichem
+- conda config --add channels insilichem/label/dev
 - conda config --add channels defaults
 - conda install -q conda conda-build
 - conda config --add channels file://$CONDA_PREFIX/conda-bld
+# Patch some chimera stuff
+- pip install -U numpy==1.12 python-dateutil -t $CHIMERADIR/lib/python2.7/site-packages;
 # Show conda info for debugging
 - conda info -a
 - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ branches:
 
 before_install:
 # Get Chimera
-- wget https://raw.githubusercontent.com/insilichem/pychimera/clean-recipe/scripts/install_chimera.sh
+- wget https://raw.githubusercontent.com/insilichem/pychimera/master/scripts/install_chimera.sh
 - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
     if [[ ! -e $HOME/chimera/bin/chimera ]]; then
       bash install_chimera.sh;
@@ -61,24 +61,13 @@ install:
 - conda config --add channels omnia
 - conda config --add channels rdkit
 - conda config --add channels insilichem
-- conda config --add channels insilichem/label/dev
-# Use my channel temporarily (testing)
-- conda config --add channels jaimergp
 - conda config --add channels defaults
 - conda install -q conda conda-build
 - conda config --add channels file://$CONDA_PREFIX/conda-bld
 # Show conda info for debugging
 - conda info -a
 - conda list
-# Get Chimera
-
-# While we modernize pychimera, tangram and gaudi recipes, use pychimera PR#13 builds
-- git clone https://github.com/insilichem/pychimera;
-  cd pychimera;
-  git checkout clean-recipe;
-  conda build -q --python=2.7 conda-recipe --no-test;
-  cd ..;
-- env
+- env | sort
 
 script:
 - conda build conda-recipe

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,11 +25,11 @@ Install the full Tangram Suite (recommended)
 Using the conda meta-package
 ============================
 
-Instead of using the Bash installer, you can use conda (if you are already using it) to create a new environment with the ``tangram`` metapackage, which will handle all the dependencies:
+Instead of using the Bash installer, you can use conda (if you are already using it) to create a new environment with the ``tangram`` metapackage, which will handle all the dependencies. While in alpha, both ``insilichem`` channels are needed (the main one and also the `dev` label):
 
 ::
 
-    conda create -n tangram -c insilichem -c conda-forge -c omnia -c rdkit tangram
+    conda create -n tangram -c insilichem/label/dev -c insilichem -c conda-forge -c omnia -c rdkit tangram
 
 Updating extensions
 ===================
@@ -38,9 +38,9 @@ Each extension will check if there's a new release available every time you laun
 
 ::
 
-    conda update -c insilichem [-c additional channels] <extension_name>
+    conda update -c insilichem/label/dev -c insilichem [-c additional channels] <extension_name>
 
-.. note:
+.. note::
 
     More ``-c`` flags might be needed, depending on the requirements. Check each extension documentation page to see the needed conda channels.
 
@@ -49,7 +49,8 @@ For example, if you want to update *gaudiview*, you would write:
 ::
 
     conda activate insilichem
-    conda update -c insilichem gaudiview
+    conda update -c insilichem/label/dev -c insilichem gaudiview
+
 
 .. _installone:
 


### PR DESCRIPTION
Remove `dev` dependencies increasingly.

- `tangram_*` packages are now in the `insilichem/label/dev` channel. Should we move them there?
- If we don't do that yet (because most packages are in early stages of development), the Tangram package should be in there as well? Probably yes...

- [x] Add `-l dev` to the Anaconda uploader.
- [x] Update docs accordingly.